### PR TITLE
Add option to fetch tags even if fetch-depth > 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ Refer [here](https://github.com/actions/checkout/blob/v1/README.md) for previous
     # Default: 1
     fetch-depth: ''
 
+    # Whether to fetch tags, even if fetch-depth > 0.
+    # Default: false
+    fetch-tags: ''
+
     # Whether to download Git-LFS files
     # Default: false
     lfs: ''

--- a/__test__/git-auth-helper.test.ts
+++ b/__test__/git-auth-helper.test.ts
@@ -760,6 +760,7 @@ async function setup(testName: string): Promise<void> {
     clean: true,
     commit: '',
     fetchDepth: 1,
+    fetchTags: false,
     lfs: false,
     submodules: false,
     nestedSubmodules: false,

--- a/__test__/input-helper.test.ts
+++ b/__test__/input-helper.test.ts
@@ -75,6 +75,7 @@ describe('input-helper tests', () => {
     expect(settings.commit).toBeTruthy()
     expect(settings.commit).toBe('1234567890123456789012345678901234567890')
     expect(settings.fetchDepth).toBe(1)
+    expect(settings.fetchTags).toBe(false)
     expect(settings.lfs).toBe(false)
     expect(settings.ref).toBe('refs/heads/some-ref')
     expect(settings.repositoryName).toBe('some-repo')

--- a/action.yml
+++ b/action.yml
@@ -56,6 +56,9 @@ inputs:
   fetch-depth:
     description: 'Number of commits to fetch. 0 indicates all history for all branches and tags.'
     default: 1
+  fetch-tags:
+    description: 'Whether to fetch tags, even if fetch-depth > 0.'
+    default: false
   lfs:
     description: 'Whether to download Git-LFS files'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -5804,10 +5804,10 @@ class GitCommandManager {
             return output.exitCode === 0;
         });
     }
-    fetch(refSpec, fetchDepth) {
+    fetch(refSpec, fetchDepth, fetchTags) {
         return __awaiter(this, void 0, void 0, function* () {
             const args = ['-c', 'protocol.version=2', 'fetch'];
-            if (!refSpec.some(x => x === refHelper.tagsRefSpec)) {
+            if (!refSpec.some(x => x === refHelper.tagsRefSpec) && !fetchTags) {
                 args.push('--no-tags');
             }
             args.push('--prune', '--progress', '--no-recurse-submodules');
@@ -5885,8 +5885,8 @@ class GitCommandManager {
     }
     log1(format) {
         return __awaiter(this, void 0, void 0, function* () {
-            var args = format ? ['log', '-1', format] : ['log', '-1'];
-            var silent = format ? false : true;
+            const args = format ? ['log', '-1', format] : ['log', '-1'];
+            const silent = format ? false : true;
             const output = yield this.execGit(args, false, silent);
             return output.stdout;
         });
@@ -6226,7 +6226,7 @@ function getSource(settings) {
             }
             else {
                 const refSpec = refHelper.getRefSpec(settings.ref, settings.commit);
-                yield git.fetch(refSpec, settings.fetchDepth);
+                yield git.fetch(refSpec, settings.fetchDepth, settings.fetchTags);
             }
             core.endGroup();
             // Checkout info
@@ -14572,6 +14572,10 @@ function getInputs() {
         result.fetchDepth = 0;
     }
     core.debug(`fetch depth = ${result.fetchDepth}`);
+    // Fetch tags
+    result.fetchTags =
+        (core.getInput('fetch-tags') || 'false').toUpperCase() === 'TRUE';
+    core.debug(`fetch tags = ${result.fetchTags}`);
     // LFS
     result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE';
     core.debug(`lfs = ${result.lfs}`);

--- a/src/git-command-manager.ts
+++ b/src/git-command-manager.ts
@@ -24,7 +24,11 @@ export interface IGitCommandManager {
     globalConfig?: boolean
   ): Promise<void>
   configExists(configKey: string, globalConfig?: boolean): Promise<boolean>
-  fetch(refSpec: string[], fetchDepth?: number): Promise<void>
+  fetch(
+    refSpec: string[],
+    fetchDepth?: number,
+    fetchTags?: boolean
+  ): Promise<void>
   getDefaultBranch(repositoryUrl: string): Promise<string>
   getWorkingDirectory(): string
   init(): Promise<void>
@@ -168,9 +172,14 @@ class GitCommandManager {
     return output.exitCode === 0
   }
 
-  async fetch(refSpec: string[], fetchDepth?: number): Promise<void> {
+  async fetch(
+    refSpec: string[],
+    fetchDepth?: number,
+    fetchTags?: boolean
+  ): Promise<void> {
     const args = ['-c', 'protocol.version=2', 'fetch']
-    if (!refSpec.some(x => x === refHelper.tagsRefSpec)) {
+
+    if (!refSpec.some(x => x === refHelper.tagsRefSpec) && !fetchTags) {
       args.push('--no-tags')
     }
 
@@ -255,8 +264,8 @@ class GitCommandManager {
   }
 
   async log1(format?: string): Promise<string> {
-    var args = format ? ['log', '-1', format] : ['log', '-1']
-    var silent = format ? false : true
+    const args = format ? ['log', '-1', format] : ['log', '-1']
+    const silent = format ? false : true
     const output = await this.execGit(args, false, silent)
     return output.stdout
   }

--- a/src/git-source-provider.ts
+++ b/src/git-source-provider.ts
@@ -141,7 +141,7 @@ export async function getSource(settings: IGitSourceSettings): Promise<void> {
       }
     } else {
       const refSpec = refHelper.getRefSpec(settings.ref, settings.commit)
-      await git.fetch(refSpec, settings.fetchDepth)
+      await git.fetch(refSpec, settings.fetchDepth, settings.fetchTags)
     }
     core.endGroup()
 

--- a/src/git-source-settings.ts
+++ b/src/git-source-settings.ts
@@ -35,6 +35,11 @@ export interface IGitSourceSettings {
   fetchDepth: number
 
   /**
+   * Fetch tags, even if fetchDepth > 0 (default: false)
+   */
+  fetchTags: boolean
+
+  /**
    * Indicates whether to fetch LFS objects
    */
   lfs: boolean

--- a/src/input-helper.ts
+++ b/src/input-helper.ts
@@ -88,6 +88,11 @@ export function getInputs(): IGitSourceSettings {
   }
   core.debug(`fetch depth = ${result.fetchDepth}`)
 
+  // Fetch tags
+  result.fetchTags =
+    (core.getInput('fetch-tags') || 'false').toUpperCase() === 'TRUE'
+  core.debug(`fetch tags = ${result.fetchTags}`)
+
   // LFS
   result.lfs = (core.getInput('lfs') || 'false').toUpperCase() === 'TRUE'
   core.debug(`lfs = ${result.lfs}`)


### PR DESCRIPTION
Adds an optional `fetch-tags` option that can be used to override the default behavior of adding the `--no-tags` arg to the generated `git fetch` command if `fetch-depth` is configured and not `0`.
This way, users can use fetch-depth while still getting the tags inside this range, which can e.g.  be important when using automatic GIT versioning plugins like [jgitver](https://github.com/jgitver/jgitver).